### PR TITLE
feat: add `Error` struct

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,40 @@
+use std::{fmt, marker::PhantomData};
+
+use crate::traits::Diagnostic;
+
+pub struct Error {
+    // A stub for getting the APIs working.
+    // To be removed and replaced with the real thing.
+    _marker: std::marker::PhantomData<*const ()>,
+}
+
+unsafe impl Sync for Error {}
+unsafe impl Send for Error {}
+
+impl Error {
+    /// Create a new error object from any error type.
+    ///
+    /// The error type must be thread safe and `'static`, so that the `Error`
+    /// will be as well.
+    ///
+    /// If the error type does not provide a backtrace, a backtrace will be
+    /// created here to ensure that a backtrace exists.
+    pub fn new<E>(_error: E) -> Self
+    where
+        E: Diagnostic + Send + Sync + 'static,
+    {
+        Self { _marker: PhantomData }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TODO: fmt::Display")
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TODO: fmt::Error")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
+mod error;
 mod panic;
 mod traits;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+pub use crate::{error::Error, traits::Diagnostic};
 
 /// Default severity for diagnostics is `Severity::Error`.
 #[derive(Copy, Clone, Debug, Eq, PartialOrd, PartialEq, Ord)]

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,0 +1,35 @@
+use garment::{Diagnostic, Error};
+
+fn get_error() -> Error {
+    use thiserror::Error;
+    #[derive(Error, Debug)]
+    #[error("TestError")]
+    struct TestError;
+    impl Diagnostic for TestError {}
+    Error::new(TestError)
+}
+
+#[test]
+fn display() {
+    let error = get_error();
+    assert_eq!(format!("{error}"), "TODO: fmt::Display")
+}
+
+#[test]
+fn debug() {
+    let error = get_error();
+    assert_eq!(format!("{error:?}"), "TODO: fmt::Error")
+}
+
+#[test]
+fn send_sync() {
+    use std::{sync::Arc, thread};
+    let error = Arc::new(get_error());
+    for _ in 0..2 {
+        let error = Arc::clone(&error);
+        // This line will fail to compile with
+        // `error[E0277]: `___` cannot be shared between threads safely`
+        // if `Error` does not implement `Send` and `Sync`.
+        _ = thread::spawn(move || format!("{error}")).join();
+    }
+}


### PR DESCRIPTION
I hate it when I see my performance profile thowing miette in the first 20 lines ... so here we go.

This PR adds the `Error` struct with a few APIs copied from https://docs.rs/miette/latest/miette/struct.Report.html#

And ... it's time for bed.