### PR TITLE
feat: implement `Report::with_source_code`

### DIFF
--- a/src/labeled_source_span.rs
+++ b/src/labeled_source_span.rs
@@ -13,4 +13,8 @@ impl LabeledSourceSpan {
     pub const fn new(label: Option<String>, offset: ByteOffset, len: usize) -> Self {
         Self { label, span: SourceSpan::new(SourceOffset::new(offset), SourceOffset::new(len)) }
     }
+
+    pub fn new_with_span(label: Option<String>, span: impl Into<SourceSpan>) -> Self {
+        Self { label, span: span.into() }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@ mod debug_report_handler;
 mod diagnostic;
 mod graphical_report_handler;
 mod labeled_source_span;
+mod named_source;
 mod panic;
 mod report;
 mod report_handler;
+mod source_code;
 mod source_offset;
 mod source_span;
 
@@ -14,8 +16,8 @@ use serde::{Deserialize, Serialize};
 pub use crate::{
     debug_report_handler::DebugReportHandler, diagnostic::Diagnostic,
     graphical_report_handler::GraphicalReportHandler, labeled_source_span::LabeledSourceSpan,
-    report::Report, report_handler::ReportHandler, source_offset::SourceOffset,
-    source_span::SourceSpan,
+    named_source::NamedSource, report::Report, report_handler::ReportHandler,
+    source_code::SourceCode, source_offset::SourceOffset, source_span::SourceSpan,
 };
 
 pub type ByteOffset = usize;

--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -1,0 +1,31 @@
+use std::fmt::Debug;
+
+use crate::SourceCode;
+
+pub struct NamedSource {
+    source: Box<dyn SourceCode + 'static>,
+    name: String,
+}
+
+impl Debug for NamedSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NamedSource").field("name", &self.name).field("source", &"<redacted>");
+        Ok(())
+    }
+}
+
+impl NamedSource {
+    pub fn new(name: impl AsRef<str>, source: impl SourceCode + Send + Sync + 'static) -> Self {
+        Self { source: Box::new(source), name: name.as_ref().to_string() }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn inner(&self) -> &(dyn SourceCode + 'static) {
+        &*self.source
+    }
+}
+
+impl SourceCode for NamedSource {}

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,12 +1,14 @@
 use std::fmt;
 
-use crate::diagnostic::Diagnostic;
+use crate::{Diagnostic, SourceCode};
 
 /// An error reporter.
 ///
 /// API taken from [std::error::Report](https://doc.rust-lang.org/std/error/struct.Report.html).
 pub struct Report<D = Box<dyn Diagnostic>> {
     diagnostic: D,
+
+    source_code: Option<Box<dyn SourceCode>>,
 }
 
 impl<D> Report<D>
@@ -16,6 +18,12 @@ where
     pub fn new(error: D) -> Report<D> {
         Self::from(error)
     }
+
+    /// Provide source code for this error
+    pub fn with_source_code(mut self, source_code: impl SourceCode + 'static) -> Self {
+        self.source_code.replace(Box::new(source_code));
+        self
+    }
 }
 
 impl<D> From<D> for Report<D>
@@ -23,7 +31,7 @@ where
     D: Diagnostic,
 {
     fn from(error: D) -> Self {
-        Self { diagnostic: error }
+        Self { diagnostic: error, source_code: None }
     }
 }
 

--- a/src/source_code.rs
+++ b/src/source_code.rs
@@ -1,0 +1,3 @@
+pub trait SourceCode: Send + Sync {}
+
+impl SourceCode for String {}

--- a/src/source_offset.rs
+++ b/src/source_offset.rs
@@ -15,3 +15,9 @@ impl SourceOffset {
         self.0
     }
 }
+
+impl From<ByteOffset> for SourceOffset {
+    fn from(bytes: ByteOffset) -> Self {
+        SourceOffset(bytes)
+    }
+}

--- a/src/source_span.rs
+++ b/src/source_span.rs
@@ -1,4 +1,4 @@
-use crate::source_offset::SourceOffset;
+use crate::{ByteOffset, SourceOffset};
 
 /// Represents the start and length of the span.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,5 +11,11 @@ pub struct SourceSpan {
 impl SourceSpan {
     pub const fn new(start: SourceOffset, length: SourceOffset) -> Self {
         Self { offset: start, length: length.offset() }
+    }
+}
+
+impl From<(ByteOffset, usize)> for SourceSpan {
+    fn from((start, len): (ByteOffset, usize)) -> Self {
+        Self { offset: SourceOffset::from(start), length: len }
     }
 }

--- a/tests/debug_report_handler.rs
+++ b/tests/debug_report_handler.rs
@@ -14,7 +14,7 @@ fn test() {
     #[error("TestError")]
     struct TestError {
         source: SourceError,
-    };
+    }
 
     impl Diagnostic for TestError {
         fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {

--- a/tests/graphical_report_handler.rs
+++ b/tests/graphical_report_handler.rs
@@ -1,4 +1,15 @@
-use garment::{Diagnostic, GraphicalReportHandler, Report, Severity};
+use std::fmt::Display;
+
+use garment::{
+    Diagnostic, GraphicalReportHandler, LabeledSourceSpan, NamedSource, Report, Severity,
+    SourceSpan,
+};
+
+fn format_report<R: AsRef<dyn Diagnostic>>(report: R) -> String {
+    let mut out = String::new();
+    GraphicalReportHandler::new().render_report(&mut out, report.as_ref()).unwrap();
+    out
+}
 
 #[test]
 fn test() {
@@ -16,4 +27,52 @@ fn test() {
     let mut out = String::new();
     GraphicalReportHandler::new().render_report(&mut out, error.as_ref()).unwrap();
     assert_eq!(&out, "severity:Error")
+}
+
+#[test]
+#[ignore]
+fn external_source() {
+    use thiserror::Error;
+    #[derive(Error, Debug)]
+    #[error("oops!")]
+    struct MyBad {
+        highlight: SourceSpan,
+    }
+
+    impl Diagnostic for MyBad {
+        fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+            Some(Box::new("try doing it better next time?"))
+        }
+
+        fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSourceSpan> + '_>> {
+            Some(Box::new(
+                [LabeledSourceSpan::new_with_span(
+                    Some("this bit here".into()),
+                    self.highlight.clone(),
+                )]
+                .into_iter(),
+            ))
+        }
+    }
+
+    let src = "source\n  text\n    here".to_string();
+    let err = Report::from(MyBad { highlight: SourceSpan::from((9, 4)) })
+        .with_source_code(NamedSource::new("bad_file.rs", src));
+    let out = format_report(err);
+    println!("Error: {}", out);
+    let expected = r#"oops::my::bad
+
+  × oops!
+   ╭─[bad_file.rs:2:3]
+ 1 │ source
+ 2 │   text
+   ·   ──┬─
+   ·     ╰── this bit here
+ 3 │     here
+   ╰────
+  help: try doing it better next time?
+"#
+    .trim_start()
+    .to_string();
+    assert_eq!(expected, out);
 }


### PR DESCRIPTION
```rust
    pub fn with_source_code(self, source_code: impl SourceCode + Send + Sync + 'static) -> Report {
        WithSourceCode {
            source_code,
            error: self,
        }
        .into()
    }
```

miette uses the `WithSourceCode` struct for converting a normal `Report` to a `Report` with source code

https://github.com/zkat/miette/blob/55bfc4201638e412dd2732d394389e22a7398822/src/eyreish/wrapper.rs#L139-L142

```rust
pub(crate) struct WithSourceCode<E, C> {
    pub(crate) error: E,
    pub(crate) source_code: C,
}
```

I couldn't figure out what the heck is going on with `E` and `C` so I gave up and threw the source code into `Report` for now.