### PR TITLE
feat: add more APIs to `Report`

### DIFF
--- a/garment-derive/src/lib.rs
+++ b/garment-derive/src/lib.rs
@@ -1,6 +1,6 @@
 use quote::quote;
 
-#[proc_macro_derive(Diagnostic)]
+#[proc_macro_derive(Diagnostic, attributes(diagnostic))]
 pub fn derive_diagnostic(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     quote!().into()
 }

--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -30,4 +30,6 @@ impl NamedSource {
     }
 }
 
-impl SourceCode for NamedSource {}
+impl SourceCode for NamedSource {
+    fn read_span(&self) {}
+}

--- a/src/source_code.rs
+++ b/src/source_code.rs
@@ -1,3 +1,21 @@
-pub trait SourceCode: Send + Sync {}
+use std::sync::Arc;
 
-impl SourceCode for String {}
+pub trait SourceCode: Send + Sync {
+    fn read_span(&self);
+}
+
+impl SourceCode for str {
+    fn read_span(&self) {}
+}
+
+impl<'s> SourceCode for &'s str {
+    fn read_span(&self) {}
+}
+
+impl SourceCode for String {
+    fn read_span(&self) {}
+}
+
+impl<T: ?Sized + SourceCode> SourceCode for Arc<T> {
+    fn read_span(&self) {}
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -3,3 +3,4 @@ mod derive;
 mod graphical_report_handler;
 mod report;
 mod report_handler;
+mod source_code;

--- a/tests/report.rs
+++ b/tests/report.rs
@@ -1,37 +1,93 @@
-use garment::{Diagnostic, Report};
+#[cfg(test)]
+mod unboxed {
+    use garment::{Diagnostic, Report};
 
-use thiserror::Error;
-#[derive(Error, Debug)]
-#[error("TestError")]
-struct TestError;
-impl Diagnostic for TestError {}
+    use thiserror::Error;
+    #[derive(Error, Debug)]
+    #[error("TestError")]
+    struct TestError;
+    impl Diagnostic for TestError {}
 
-fn get_error() -> Report<TestError> {
-    let test_error = TestError;
-    Report::new(test_error)
+    fn get_error() -> Report<TestError> {
+        let test_error = TestError;
+        Report::new(test_error)
+    }
+
+    #[test]
+    fn send_sync() {
+        use std::{sync::Arc, thread};
+        let error = Arc::new(get_error());
+        for _ in 0..2 {
+            let error = Arc::clone(&error);
+            // This line will fail to compile with
+            // `error[E0277]: `___` cannot be shared between threads safely`
+            // if `Error` does not implement `Send` and `Sync`.
+            _ = thread::spawn(move || format!("{error}")).join();
+        }
+    }
+
+    #[test]
+    fn display() {
+        let error = get_error();
+        assert_eq!(format!("{error}"), "TODO: fmt::Display");
+    }
+
+    #[test]
+    fn debug() {
+        let error = get_error();
+        assert_eq!(format!("{error:?}"), "TODO: fmt::Debug");
+    }
+
+    #[test]
+    fn as_ref() {
+        let error = get_error();
+        assert_eq!(error.severity(), None);
+    }
 }
 
-#[test]
-fn display() {
-    let error = get_error();
-    assert_eq!(format!("{error}"), "TODO: fmt::Display");
-}
+#[cfg(test)]
+mod boxed {
+    use garment::{Diagnostic, Report};
 
-#[test]
-fn debug() {
-    let error = get_error();
-    assert_eq!(format!("{error:?}"), "TODO: fmt::Debug");
-}
+    use thiserror::Error;
+    #[derive(Error, Debug)]
+    #[error("TestError")]
+    struct TestError;
+    impl Diagnostic for TestError {}
 
-#[test]
-fn send_sync() {
-    use std::{sync::Arc, thread};
-    let error = Arc::new(get_error());
-    for _ in 0..2 {
-        let error = Arc::clone(&error);
-        // This line will fail to compile with
-        // `error[E0277]: `___` cannot be shared between threads safely`
-        // if `Error` does not implement `Send` and `Sync`.
-        _ = thread::spawn(move || format!("{error}")).join();
+    fn get_error() -> Report<Box<dyn Diagnostic + Send + Sync>> {
+        let test_error = TestError;
+        Report::new_boxed(Box::new(test_error))
+    }
+
+    #[test]
+    fn send_sync() {
+        use std::{sync::Arc, thread};
+        let error = Arc::new(get_error());
+        for _ in 0..2 {
+            let error = Arc::clone(&error);
+            // This line will fail to compile with
+            // `error[E0277]: `___` cannot be shared between threads safely`
+            // if `Error` does not implement `Send` and `Sync`.
+            _ = thread::spawn(move || format!("{error}")).join();
+        }
+    }
+
+    #[test]
+    fn display() {
+        let error = get_error();
+        assert_eq!(format!("{error}"), "TODO: fmt::Display");
+    }
+
+    #[test]
+    fn debug() {
+        let error = get_error();
+        assert_eq!(format!("{error:?}"), "TODO: fmt::Debug");
+    }
+
+    #[test]
+    fn as_ref() {
+        let error = get_error();
+        assert_eq!(error.severity(), None);
     }
 }

--- a/tests/source_code.rs
+++ b/tests/source_code.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+
+use garment::SourceCode;
+
+#[test]
+fn compile_test() {
+    let soure_code = "";
+    soure_code.read_span();
+
+    let soure_code = String::new();
+    soure_code.read_span();
+
+    let soure_code = Arc::new("");
+    soure_code.read_span();
+
+    let soure_code = Arc::new(String::new());
+    soure_code.read_span();
+}


### PR DESCRIPTION
Report has two use cases:

1. Construct from a static object.

```rust
struct TestError;
let report: Report<TestError> = Report::new(TestError);
```

2. Save into a collection.

```
struct TestError1;
struct TestError2;
let reports: Vec<Report<Box<dyn Diagnostic>>> = vec![
    Report::new_boxed(Box::new(TestError1)),
    Report::new_boxed(Box::new(TestError2)),
];
```